### PR TITLE
Fix inclusive gateway return

### DIFF
--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/cmd/BackTaskCmd.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/cmd/BackTaskCmd.java
@@ -199,6 +199,11 @@ public class BackTaskCmd implements Command<String>, Serializable {
         List<ExecutionEntity> executions = executionEntityManager.findChildExecutionsByProcessInstanceId(processInstanceId);
         Set<String> parentExecutionIds = FlowableJumpUtils.getParentExecutionIdsByActivityId(executions, sourceRealActivityId);
         String realParentExecutionId = FlowableJumpUtils.getParentExecutionIdFromParentIds(taskExecution, parentExecutionIds);
-        return executionEntityManager.findExecutionsByParentExecutionAndActivityIds(realParentExecutionId, activityIds);
+        List<ExecutionEntity> realExecutions = executionEntityManager.findExecutionsByParentExecutionAndActivityIds(realParentExecutionId, activityIds);
+        if (realExecutions.isEmpty() && taskExecution != null) {
+            // 当未查询到符合条件的执行时，默认使用当前任务对应的执行，避免未能产生目标节点
+            realExecutions = Collections.singletonList(taskExecution);
+        }
+        return realExecutions;
     }
 }


### PR DESCRIPTION
## Summary
- fix BackTaskCmd so a target node is still created when no matching executions are found

## Testing
- `mvn -q -pl yudao-module-bpm/yudao-module-bpm-biz -am test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684109b0e8f083299fafca6770951a4f