### PR TITLE
Add worktime handler for BPM nodes

### DIFF
--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/vo/model/simple/BpmSimpleModelNodeVO.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/vo/model/simple/BpmSimpleModelNodeVO.java
@@ -81,6 +81,11 @@ public class BpmSimpleModelNodeVO {
      */
     private TimeoutHandler timeoutHandler;
 
+    /**
+     * 节点工时设置
+     */
+    private WorkTimeHandler workTimeHandler;
+
     @Schema(description = "审批节点的审批人与发起人相同时，对应的处理类型", example = "1")
     @InEnum(BpmUserTaskAssignStartUserHandlerTypeEnum.class)
     private Integer assignStartUserHandlerType;
@@ -200,11 +205,22 @@ public class BpmSimpleModelNodeVO {
         //自动跳转-跳转节点
         @Schema(description = "任务审批节点超时跳转Id", example = "Activity_1")
         private String returnNodeId;
-        //工时时长类型
+    }
+
+    @Schema(description = "工时设置")
+    @Valid
+    @Data
+    public static class WorkTimeHandler {
+
         @Schema(description = "工作时间类型", example = "1")
         private Integer workTimeType;
+
         @Schema(description = "是否按工作时间计算超时", example = "false")
-        private Boolean workTimeEnable=false;
+        private Boolean workTimeEnable = false;
+
+        @Schema(description = "工时时间", requiredMode = Schema.RequiredMode.REQUIRED, example = "PT6H")
+        @NotEmpty(message = "工时时间不能为空")
+        private String timeDuration;
     }
 
     @Schema(description = "空处理策略")

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/framework/flowable/core/util/SimpleModelUtils.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/framework/flowable/core/util/SimpleModelUtils.java
@@ -368,7 +368,7 @@ public class SimpleModelUtils {
 
             // 2. 添加用户任务的 Timer Boundary Event, 用于任务的审批超时处理
             if (node.getTimeoutHandler() != null && node.getTimeoutHandler().getEnable()) {
-                BoundaryEvent boundaryEvent = buildUserTaskTimeoutBoundaryEvent(userTask, node.getTimeoutHandler());
+                BoundaryEvent boundaryEvent = buildUserTaskTimeoutBoundaryEvent(userTask, node.getTimeoutHandler(), node.getWorkTimeHandler());
                 flowElements.add(boundaryEvent);
             }
             return flowElements;
@@ -387,7 +387,8 @@ public class SimpleModelUtils {
          * @return BoundaryEvent 超时事件
          */
         private BoundaryEvent buildUserTaskTimeoutBoundaryEvent(UserTask userTask,
-                                                                BpmSimpleModelNodeVO.TimeoutHandler timeoutHandler) {
+                                                                BpmSimpleModelNodeVO.TimeoutHandler timeoutHandler,
+                                                                BpmSimpleModelNodeVO.WorkTimeHandler workTimeHandler) {
             // 1.1 定时器边界事件
             BoundaryEvent boundaryEvent = new BoundaryEvent();
             boundaryEvent.setId("Event-" + IdUtil.fastUUID());
@@ -398,7 +399,7 @@ public class SimpleModelUtils {
             String actualTimeDuration = timeoutHandler.getTimeDuration();
             
             // 如果启用了工作时间计算，需要特殊处理
-            if (Boolean.TRUE.equals(timeoutHandler.getWorkTimeEnable()) && timeoutHandler.getWorkTimeType() != null) {
+            if (workTimeHandler != null && Boolean.TRUE.equals(workTimeHandler.getWorkTimeEnable()) && workTimeHandler.getWorkTimeType() != null) {
                 // 注意：边界事件的工作时间计算需要在运行时进行，此处保持原始时间
                 // 实际的工作时间计算将在任务创建时进行，边界事件将通过特殊逻辑处理
 //                log.info("[buildUserTaskTimeoutBoundaryEvent][用户任务({})启用工作时间计算，保存原始超时间隔: {}]",
@@ -424,11 +425,11 @@ public class SimpleModelUtils {
             addExtensionElement(boundaryEvent, USER_TASK_TIMEOUT_HANDLER_TYPE, timeoutHandler.getType());
             
             // 2.3 如果启用工作时间，添加相关扩展元素供后续处理使用
-            if (Boolean.TRUE.equals(timeoutHandler.getWorkTimeEnable())) {
+            if (workTimeHandler != null && Boolean.TRUE.equals(workTimeHandler.getWorkTimeEnable())) {
                 addExtensionElement(boundaryEvent, USER_TASK_WORK_TIME_ENABLE, "true");
-                if (timeoutHandler.getWorkTimeType() != null) {
-                    addExtensionElement(boundaryEvent, USER_TASK_WORK_TIME_TYPE, 
-                            String.valueOf(timeoutHandler.getWorkTimeType()));
+                if (workTimeHandler.getWorkTimeType() != null) {
+                    addExtensionElement(boundaryEvent, USER_TASK_WORK_TIME_TYPE,
+                            String.valueOf(workTimeHandler.getWorkTimeType()));
                 }
             }
             
@@ -461,23 +462,27 @@ public class SimpleModelUtils {
             // 添加用户任务的空处理元素
             addAssignEmptyHandlerType(node.getAssignEmptyHandler(), userTask);
             //  设置审批任务的截止时间
+            if (node.getWorkTimeHandler() != null) {
+                userTask.setDueDate(node.getWorkTimeHandler().getTimeDuration());
+            }
             if (node.getTimeoutHandler() != null && node.getTimeoutHandler().getEnable()) {
-                userTask.setDueDate(node.getTimeoutHandler().getTimeDuration());
                 //设置超时后的处理方式 判断是否需要跳转  returnNodeId 是否为空 不为空则跳转到指定节点
                 if (StrUtil.isNotBlank(node.getTimeoutHandler().getReturnNodeId())) {
                     addExtensionElement(userTask, USER_TASK_TIMEOUT_JUMP_TASK_ID, node.getTimeoutHandler().getReturnNodeId());
                     // 添加自动跳转前的最大提醒次数
                     if (Objects.equals(BpmUserTaskTimeoutHandlerTypeEnum.REMINDER.getType(), node.getTimeoutHandler().getType()) &&
                             node.getTimeoutHandler().getMaxRemindCount() != null) {
-                        addExtensionElement(userTask, USER_TASK_TIMEOUT_JUMP_MAX_REMIND_COUNT, 
+                        addExtensionElement(userTask, USER_TASK_TIMEOUT_JUMP_MAX_REMIND_COUNT,
                                 String.valueOf(node.getTimeoutHandler().getMaxRemindCount()));
                     }
                 }
-                addWorkTimeEnable(node.getTimeoutHandler().getWorkTimeEnable(), userTask);
-                if (Boolean.TRUE.equals(node.getTimeoutHandler().getWorkTimeEnable())
-                        && node.getTimeoutHandler().getWorkTimeType() != null) {
+            }
+            if (node.getWorkTimeHandler() != null) {
+                addWorkTimeEnable(node.getWorkTimeHandler().getWorkTimeEnable(), userTask);
+                if (Boolean.TRUE.equals(node.getWorkTimeHandler().getWorkTimeEnable())
+                        && node.getWorkTimeHandler().getWorkTimeType() != null) {
                     addExtensionElement(userTask, USER_TASK_WORK_TIME_TYPE,
-                            String.valueOf(node.getTimeoutHandler().getWorkTimeType()));
+                            String.valueOf(node.getWorkTimeHandler().getWorkTimeType()));
                 }
             }
 


### PR DESCRIPTION
## Summary
- separate work time configuration from timeout handler
- add `WorkTimeHandler` to BPM model node definition
- apply work time config when building user tasks

## Testing
- `mvn -q -pl yudao-module-bpm -am -DskipTests test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68416c066b6c8329b1bb6c6cddcf4e00