### PR TITLE
Refactor timeout handling

### DIFF
--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/vo/model/simple/BpmSimpleModelNodeVO.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/vo/model/simple/BpmSimpleModelNodeVO.java
@@ -81,6 +81,11 @@ public class BpmSimpleModelNodeVO {
      */
     private TimeoutHandler timeoutHandler;
 
+    /**
+     * 节点工时设置
+     */
+    private WorkTimeHandler workTimeHandler;
+
     @Schema(description = "审批节点的审批人与发起人相同时，对应的处理类型", example = "1")
     @InEnum(BpmUserTaskAssignStartUserHandlerTypeEnum.class)
     private Integer assignStartUserHandlerType;
@@ -200,11 +205,22 @@ public class BpmSimpleModelNodeVO {
         //自动跳转-跳转节点
         @Schema(description = "任务审批节点超时跳转Id", example = "Activity_1")
         private String returnNodeId;
-        //工时时长类型
+    }
+
+    @Schema(description = "工时设置")
+    @Valid
+    @Data
+    public static class WorkTimeHandler {
+
         @Schema(description = "工作时间类型", example = "1")
         private Integer workTimeType;
+
         @Schema(description = "是否按工作时间计算超时", example = "false")
-        private Boolean workTimeEnable=false;
+        private Boolean workTimeEnable = false;
+
+        @Schema(description = "工时时间", requiredMode = Schema.RequiredMode.REQUIRED, example = "PT6H")
+        @NotEmpty(message = "工时时间不能为空")
+        private String timeDuration;
     }
 
     @Schema(description = "空处理策略")

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/BpmTaskController.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/BpmTaskController.java
@@ -18,7 +18,6 @@ import cn.iocoder.yudao.module.bpm.service.definition.BpmModelService;
 import cn.iocoder.yudao.module.bpm.service.definition.BpmProcessDefinitionService;
 import cn.iocoder.yudao.module.bpm.service.task.BpmProcessInstanceService;
 import cn.iocoder.yudao.module.bpm.service.task.BpmTaskService;
-import cn.iocoder.yudao.module.bpm.service.worktime.BpmWorkTimeService;
 import cn.iocoder.yudao.module.system.api.dept.DeptApi;
 import cn.iocoder.yudao.module.system.api.dept.dto.DeptRespDTO;
 import cn.iocoder.yudao.module.system.api.user.AdminUserApi;
@@ -74,8 +73,6 @@ public class BpmTaskController {
     private DeptApi deptApi;
     @Resource
     private BpmModelService modelService;
-    @Resource
-    private BpmWorkTimeService workTimeService;
     @GetMapping("todo-page")
     @Operation(summary = "获取 Todo 待办任务分页")
     @PreAuthorize("@ss.hasPermission('bpm:task:query')")

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/framework/flowable/core/util/SimpleModelUtils.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/framework/flowable/core/util/SimpleModelUtils.java
@@ -368,7 +368,7 @@ public class SimpleModelUtils {
 
             // 2. 添加用户任务的 Timer Boundary Event, 用于任务的审批超时处理
             if (node.getTimeoutHandler() != null && node.getTimeoutHandler().getEnable()) {
-                BoundaryEvent boundaryEvent = buildUserTaskTimeoutBoundaryEvent(userTask, node.getTimeoutHandler());
+                BoundaryEvent boundaryEvent = buildUserTaskTimeoutBoundaryEvent(userTask, node.getTimeoutHandler(), node.getWorkTimeHandler());
                 flowElements.add(boundaryEvent);
             }
             return flowElements;
@@ -387,7 +387,8 @@ public class SimpleModelUtils {
          * @return BoundaryEvent 超时事件
          */
         private BoundaryEvent buildUserTaskTimeoutBoundaryEvent(UserTask userTask,
-                                                                BpmSimpleModelNodeVO.TimeoutHandler timeoutHandler) {
+                                                                BpmSimpleModelNodeVO.TimeoutHandler timeoutHandler,
+                                                                BpmSimpleModelNodeVO.WorkTimeHandler workTimeHandler) {
             // 1.1 定时器边界事件
             BoundaryEvent boundaryEvent = new BoundaryEvent();
             boundaryEvent.setId("Event-" + IdUtil.fastUUID());
@@ -398,7 +399,7 @@ public class SimpleModelUtils {
             String actualTimeDuration = timeoutHandler.getTimeDuration();
             
             // 如果启用了工作时间计算，需要特殊处理
-            if (Boolean.TRUE.equals(timeoutHandler.getWorkTimeEnable()) && timeoutHandler.getWorkTimeType() != null) {
+            if (workTimeHandler != null && Boolean.TRUE.equals(workTimeHandler.getWorkTimeEnable()) && workTimeHandler.getWorkTimeType() != null) {
                 // 注意：边界事件的工作时间计算需要在运行时进行，此处保持原始时间
                 // 实际的工作时间计算将在任务创建时进行，边界事件将通过特殊逻辑处理
 //                log.info("[buildUserTaskTimeoutBoundaryEvent][用户任务({})启用工作时间计算，保存原始超时间隔: {}]",
@@ -424,11 +425,11 @@ public class SimpleModelUtils {
             addExtensionElement(boundaryEvent, USER_TASK_TIMEOUT_HANDLER_TYPE, timeoutHandler.getType());
             
             // 2.3 如果启用工作时间，添加相关扩展元素供后续处理使用
-            if (Boolean.TRUE.equals(timeoutHandler.getWorkTimeEnable())) {
+            if (workTimeHandler != null && Boolean.TRUE.equals(workTimeHandler.getWorkTimeEnable())) {
                 addExtensionElement(boundaryEvent, USER_TASK_WORK_TIME_ENABLE, "true");
-                if (timeoutHandler.getWorkTimeType() != null) {
-                    addExtensionElement(boundaryEvent, USER_TASK_WORK_TIME_TYPE, 
-                            String.valueOf(timeoutHandler.getWorkTimeType()));
+                if (workTimeHandler.getWorkTimeType() != null) {
+                    addExtensionElement(boundaryEvent, USER_TASK_WORK_TIME_TYPE,
+                            String.valueOf(workTimeHandler.getWorkTimeType()));
                 }
             }
             
@@ -461,23 +462,27 @@ public class SimpleModelUtils {
             // 添加用户任务的空处理元素
             addAssignEmptyHandlerType(node.getAssignEmptyHandler(), userTask);
             //  设置审批任务的截止时间
+            if (node.getWorkTimeHandler() != null) {
+                userTask.setDueDate(node.getWorkTimeHandler().getTimeDuration());
+            }
             if (node.getTimeoutHandler() != null && node.getTimeoutHandler().getEnable()) {
-                userTask.setDueDate(node.getTimeoutHandler().getTimeDuration());
                 //设置超时后的处理方式 判断是否需要跳转  returnNodeId 是否为空 不为空则跳转到指定节点
                 if (StrUtil.isNotBlank(node.getTimeoutHandler().getReturnNodeId())) {
                     addExtensionElement(userTask, USER_TASK_TIMEOUT_JUMP_TASK_ID, node.getTimeoutHandler().getReturnNodeId());
                     // 添加自动跳转前的最大提醒次数
                     if (Objects.equals(BpmUserTaskTimeoutHandlerTypeEnum.REMINDER.getType(), node.getTimeoutHandler().getType()) &&
                             node.getTimeoutHandler().getMaxRemindCount() != null) {
-                        addExtensionElement(userTask, USER_TASK_TIMEOUT_JUMP_MAX_REMIND_COUNT, 
+                        addExtensionElement(userTask, USER_TASK_TIMEOUT_JUMP_MAX_REMIND_COUNT,
                                 String.valueOf(node.getTimeoutHandler().getMaxRemindCount()));
                     }
                 }
-                addWorkTimeEnable(node.getTimeoutHandler().getWorkTimeEnable(), userTask);
-                if (Boolean.TRUE.equals(node.getTimeoutHandler().getWorkTimeEnable())
-                        && node.getTimeoutHandler().getWorkTimeType() != null) {
+            }
+            if (node.getWorkTimeHandler() != null) {
+                addWorkTimeEnable(node.getWorkTimeHandler().getWorkTimeEnable(), userTask);
+                if (Boolean.TRUE.equals(node.getWorkTimeHandler().getWorkTimeEnable())
+                        && node.getWorkTimeHandler().getWorkTimeType() != null) {
                     addExtensionElement(userTask, USER_TASK_WORK_TIME_TYPE,
-                            String.valueOf(node.getTimeoutHandler().getWorkTimeType()));
+                            String.valueOf(node.getWorkTimeHandler().getWorkTimeType()));
                 }
             }
 

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/BpmTaskServiceImpl.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/BpmTaskServiceImpl.java
@@ -1788,139 +1788,12 @@ public class BpmTaskServiceImpl implements BpmTaskService {
 
         // 2. 遍历任务执行超时处理
         taskList.forEach(task -> FlowableUtils.execute(task.getTenantId(), () -> {
-            // 检查是否启用了工作时间计算
             BpmnModel bpmnModel = modelService.getBpmnModelByDefinitionId(task.getProcessDefinitionId());
             FlowElement userTaskElement = BpmnModelUtils.getFlowElementById(bpmnModel, task.getTaskDefinitionKey());
-            BpmnModelUtils.WorkTimeConfig workTimeConfig = BpmnModelUtils.getWorkTimeConfig(userTaskElement);
-            
-            // 如果启用了工作时间计算，需要特殊处理
-            if (workTimeConfig.isEnabled() && task.getDueDate() != null) {
-                boolean shouldProcessTimeout = handleWorkTimeTimeout(task, processInstance, userTaskElement, handlerType);
-                if (!shouldProcessTimeout) {
-                    return;
-                }
-            }
-            
+
             // 执行具体的超时处理逻辑
             executeTimeoutHandler(task, processInstance, userTaskElement, handlerType);
         }));
-    }
-
-    /**
-     * 处理工作时间模式的超时逻辑
-     * 
-     * @param task 任务
-     * @param processInstance 流程实例
-     * @param userTaskElement 用户任务元素
-     * @param handlerType 处理类型
-     * @return 是否应该继续处理超时
-     */
-    private boolean handleWorkTimeTimeout(Task task, ProcessInstance processInstance, 
-                                        FlowElement userTaskElement, Integer handlerType) {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime dueTime = DateUtils.of(task.getDueDate());
-        
-        // 添加时间容差（60秒），避免因为微小的时间差异导致误判
-        Duration tolerance = Duration.ofSeconds(60);
-        
-        log.info("[handleWorkTimeTimeout][任务({})时间比较: 当前时间={}, 截止时间={}, 容差={}秒]", 
-                task.getId(), now, dueTime, tolerance.toSeconds());
-        
-        // 检查是否已经记录过首次工作时间超时
-        String firstTimeoutKey = "worktime_first_timeout_" + task.getId();
-        String originalIntervalKey = "worktime_original_interval_" + task.getId();
-        
-        LocalDateTime firstTimeoutTime = (LocalDateTime) runtimeService.getVariable(task.getExecutionId(), firstTimeoutKey);
-        String originalInterval = (String) runtimeService.getVariable(task.getExecutionId(), originalIntervalKey);
-        
-        // 如果是首次处理工作时间超时
-        if (firstTimeoutTime == null) {
-            // 计算时间窗口：[截止时间-容差, 截止时间+容差]
-            LocalDateTime dueMinusTolerance = dueTime.minus(tolerance);
-            LocalDateTime duePlusTolerance = dueTime.plus(tolerance);
-            Duration timeDiff = Duration.between(dueTime, now);
-            
-            // 如果当前时间在容差窗口内，执行超时处理
-            if (now.isAfter(dueMinusTolerance) && now.isBefore(duePlusTolerance)) {
-                // 记录首次超时时间和原始间隔
-                runtimeService.setVariable(task.getExecutionId(), firstTimeoutKey, now);
-                
-                // 从边界事件扩展元素中获取原始间隔
-                if (originalInterval == null) {
-                    originalInterval = getOriginalTimeoutInterval(userTaskElement);
-                    runtimeService.setVariable(task.getExecutionId(), originalIntervalKey, originalInterval);
-                }
-                
-                if (timeDiff.isNegative()) {
-                    // 当前时间早于截止时间
-                    log.info("[handleWorkTimeTimeout][任务({})首次工作时间处理，当前时间({})早于截止时间({})约{}，在容差窗口内，执行超时处理]", 
-                            task.getId(), now, dueTime, timeDiff.abs());
-                } else {
-                    // 当前时间晚于截止时间
-                    log.info("[handleWorkTimeTimeout][任务({})首次工作时间处理，当前时间({})晚于截止时间({})约{}，在容差窗口内，执行超时处理]", 
-                            task.getId(), now, dueTime, timeDiff);
-                }
-                return true;
-            } else {
-                // 不在容差窗口内，跳过处理
-                if (now.isBefore(dueMinusTolerance)) {
-                    log.info("[handleWorkTimeTimeout][任务({})首次工作时间检查，当前时间({})过早，距离截止时间({})还有{}，继续等待下次检测]", 
-                            task.getId(), now, dueTime, timeDiff.abs());
-                } else {
-                    log.info("[handleWorkTimeTimeout][任务({})首次工作时间检查，当前时间({})过晚，已超过截止时间({})约{}，执行延迟超时处理]", 
-                            task.getId(), now, dueTime, timeDiff);
-                    
-                    // 记录首次超时时间和原始间隔（用于可能的后续提醒）
-                    runtimeService.setVariable(task.getExecutionId(), firstTimeoutKey, now);
-                    if (originalInterval == null) {
-                        originalInterval = getOriginalTimeoutInterval(userTaskElement);
-                        runtimeService.setVariable(task.getExecutionId(), originalIntervalKey, originalInterval);
-                    }
-                    return true; // 执行延迟超时处理
-                }
-                return false; // 过早情况返回false，继续等待
-            }
-        } else {
-            // 后续提醒：检查是否到了下一个提醒时间
-            if (originalInterval != null) {
-                Duration intervalDuration = parseIntervalDuration(originalInterval);
-                
-                // 计算应该提醒的次数
-                long reminderCount = Duration.between(firstTimeoutTime, now).dividedBy(intervalDuration) + 1;
-                LocalDateTime expectedReminderTime = firstTimeoutTime.plus(intervalDuration.multipliedBy(reminderCount - 1));
-                
-                // 计算时间窗口：[预期提醒时间-容差, 预期提醒时间+容差]
-                LocalDateTime expectedMinusTolerance = expectedReminderTime.minus(tolerance);
-                LocalDateTime expectedPlusTolerance = expectedReminderTime.plus(tolerance);
-                Duration timeDiff = Duration.between(expectedReminderTime, now);
-                
-                // 如果当前时间在容差窗口内，执行超时处理
-                if (now.isAfter(expectedMinusTolerance) && now.isBefore(expectedPlusTolerance)) {
-                    if (timeDiff.isNegative()) {
-                        // 当前时间早于预期提醒时间
-                        log.info("[handleWorkTimeTimeout][任务({})后续提醒处理，当前时间({})早于预期提醒时间({})约{}，在容差窗口内，第{}次提醒]", 
-                                task.getId(), now, expectedReminderTime, timeDiff.abs(), reminderCount);
-                    } else {
-                        // 当前时间晚于预期提醒时间
-                        log.info("[handleWorkTimeTimeout][任务({})后续提醒处理，当前时间({})晚于预期提醒时间({})约{}，在容差窗口内，第{}次提醒]", 
-                                task.getId(), now, expectedReminderTime, timeDiff, reminderCount);
-                    }
-                    return true;
-                } else {
-                    // 不在容差窗口内，跳过处理
-                    if (now.isBefore(expectedMinusTolerance)) {
-                        log.info("[handleWorkTimeTimeout][任务({})后续提醒检查，当前时间({})过早，距离预期提醒时间({})还有{}，继续等待下次检测]", 
-                                task.getId(), now, expectedReminderTime, timeDiff.abs());
-                        return false; // 继续等待
-                    } else {
-                        log.info("[handleWorkTimeTimeout][任务({})后续提醒检查，当前时间({})过晚，已超过预期提醒时间({})约{}，执行延迟提醒]", 
-                                task.getId(), now, expectedReminderTime, timeDiff);
-                        return true; // 执行延迟提醒
-                    }
-                }
-            }
-            return true;
-        }
     }
 
     /**
@@ -1970,91 +1843,29 @@ public class BpmTaskServiceImpl implements BpmTaskService {
                 .setTaskName(task.getName())
                 .setAssigneeUserId(Long.parseLong(task.getAssignee())));
 
-        // 检查是否设置了超时跳转目标节点
         String targetTaskId = BpmnModelUtils.parseTimeoutReturnNodeId(userTaskElement);
-        
-        if (StrUtil.isNotEmpty(targetTaskId)) {
-            // 对于工作时间模式，检查提醒次数
-            BpmnModelUtils.WorkTimeConfig workTimeConfig = BpmnModelUtils.getWorkTimeConfig(userTaskElement);
-            
-            if (workTimeConfig.isEnabled()) {
-                // 工作时间模式：检查是否达到最大提醒次数
-                String firstTimeoutKey = "worktime_first_timeout_" + task.getId();
-                String originalIntervalKey = "worktime_original_interval_" + task.getId();
-                
-                LocalDateTime firstTimeoutTime = (LocalDateTime) runtimeService.getVariable(task.getExecutionId(), firstTimeoutKey);
-                String originalInterval = (String) runtimeService.getVariable(task.getExecutionId(), originalIntervalKey);
-                
-                if (firstTimeoutTime != null && originalInterval != null) {
-                    Duration intervalDuration = parseIntervalDuration(originalInterval);
-                    long currentReminderCount = Duration.between(firstTimeoutTime, LocalDateTime.now()).dividedBy(intervalDuration) + 1;
-                    
-                    // 获取最大提醒次数
-                    String maxRemindCountStr = BpmnModelUtils.parseExtensionElement(userTaskElement,
-                            BpmnModelConstants.USER_TASK_TIMEOUT_JUMP_MAX_REMIND_COUNT);
-                    int maxRemindCount = StrUtil.isEmpty(maxRemindCountStr) ? 1 : Integer.parseInt(maxRemindCountStr);
-                    
-                    if (currentReminderCount >= maxRemindCount) {
-                        log.info("[handleTimeoutReminder][工作时间任务({})提醒次数({})达到上限({}), 执行自动跳转到节点({})]",
-                                task.getId(), currentReminderCount, maxRemindCount, targetTaskId);
-                        
-                        // 清除工作时间相关变量
-                        runtimeService.removeVariable(task.getExecutionId(), firstTimeoutKey);
-                        runtimeService.removeVariable(task.getExecutionId(), originalIntervalKey);
-                        
-                        // 执行自动跳转
-                        timeoutTask(Long.parseLong(task.getAssignee()),
-                                new BpmTaskRejectReqVO().setId(task.getId())
-                                        .setReason(BpmReasonEnum.TIMEOUT_JUMP.getReason()));
-                    }
-                }
-            } else {
-                // 标准模式：使用原有的提醒次数逻辑
-                String taskKey = task.getId();
-                int reminderCount = taskReminderCountMap.getOrDefault(taskKey, 0) + 1;
-                taskReminderCountMap.put(taskKey, reminderCount);
-                
-                String maxRemindCountStr = BpmnModelUtils.parseExtensionElement(userTaskElement,
-                        BpmnModelConstants.USER_TASK_TIMEOUT_JUMP_MAX_REMIND_COUNT);
-                int maxRemindCount = StrUtil.isEmpty(maxRemindCountStr) ? 1 : Integer.parseInt(maxRemindCountStr);
-                
-                if (reminderCount >= maxRemindCount) {
-                    log.info("[handleTimeoutReminder][标准任务({})提醒次数({})达到上限({}), 执行自动跳转到节点({})]",
-                            taskKey, reminderCount, maxRemindCount, targetTaskId);
-                    taskReminderCountMap.remove(taskKey);
-                    timeoutTask(Long.parseLong(task.getAssignee()),
-                            new BpmTaskRejectReqVO().setId(task.getId())
-                                    .setReason(BpmReasonEnum.TIMEOUT_JUMP.getReason()));
-                }
-            }
+        if (StrUtil.isEmpty(targetTaskId)) {
+            return;
+        }
+
+        String taskKey = task.getId();
+        int reminderCount = taskReminderCountMap.getOrDefault(taskKey, 0) + 1;
+        taskReminderCountMap.put(taskKey, reminderCount);
+
+        String maxRemindCountStr = BpmnModelUtils.parseExtensionElement(userTaskElement,
+                BpmnModelConstants.USER_TASK_TIMEOUT_JUMP_MAX_REMIND_COUNT);
+        int maxRemindCount = StrUtil.isEmpty(maxRemindCountStr) ? 1 : Integer.parseInt(maxRemindCountStr);
+
+        if (reminderCount >= maxRemindCount) {
+            log.info("[handleTimeoutReminder][任务({})提醒次数({})达到上限({}), 执行自动跳转到节点({})]",
+                    taskKey, reminderCount, maxRemindCount, targetTaskId);
+            taskReminderCountMap.remove(taskKey);
+            timeoutTask(Long.parseLong(task.getAssignee()),
+                    new BpmTaskRejectReqVO().setId(task.getId())
+                            .setReason(BpmReasonEnum.TIMEOUT_JUMP.getReason()));
         }
     }
 
-    /**
-     * 获取原始的超时间隔设置
-     */
-    private String getOriginalTimeoutInterval(FlowElement userTaskElement) {
-        // 从边界事件的扩展元素中获取原始间隔
-        // 这需要在边界事件创建时保存
-        String originalInterval = BpmnModelUtils.parseExtensionElement(userTaskElement, "originalTimeDuration");
-        if (StrUtil.isEmpty(originalInterval)) {
-            // 如果没有保存，尝试从其他地方获取，或使用默认值
-            originalInterval = "PT12M"; // 默认12分钟
-        }
-        return originalInterval;
-    }
-
-    /**
-     * 解析时间间隔字符串为Duration
-     */
-    private Duration parseIntervalDuration(String intervalStr) {
-        try {
-            return Duration.parse(intervalStr);
-        } catch (Exception e) {
-            log.warn("[parseIntervalDuration][解析时间间隔失败: {}，使用默认12分钟]", intervalStr);
-            return Duration.ofMinutes(12);
-        }
-    }
 
     @Override
     public void processDelayTimerTimeout(String processInstanceId, String taskDefineKey) {


### PR DESCRIPTION
## Summary
- remove worktime-specific timeout logic from `BpmTaskServiceImpl`
- simplify timeout reminder handling
- drop unused work time service injection

## Testing
- `mvn -q -pl yudao-module-bpm -am -DskipTests test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68416c066b6c8329b1bb6c6cddcf4e00