### PR TITLE
Implement auto task delegate for auto approve nodes

### DIFF
--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/framework/flowable/core/listener/BpmAutoTaskDelegate.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/framework/flowable/core/listener/BpmAutoTaskDelegate.java
@@ -1,0 +1,24 @@
+package cn.iocoder.yudao.module.bpm.framework.flowable.core.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.delegate.JavaDelegate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 自动任务执行的 {@link JavaDelegate} 实现类
+ *
+ * 用于仿钉钉流程设计器中“自动通过”节点。
+ */
+@Component(BpmAutoTaskDelegate.BEAN_NAME)
+@Slf4j
+public class BpmAutoTaskDelegate implements JavaDelegate {
+
+    public static final String BEAN_NAME = "bpmAutoTaskDelegate";
+
+    @Override
+    public void execute(DelegateExecution execution) {
+        log.info("[execute][流程({}) 自动任务({}) 自动完成]", execution.getProcessInstanceId(), execution.getCurrentActivityId());
+        // 无实际逻辑，流程会自动流转到下一个节点
+    }
+}


### PR DESCRIPTION
## Summary
- add `BpmAutoTaskDelegate` to handle auto nodes
- convert auto-approve user tasks to service tasks in `SimpleModelUtils`

## Testing
- `mvn` not available in container so build/tests were skipped

------
https://chatgpt.com/codex/tasks/task_b_6842cab583788331ac075d7bdc911d2e