### PR TITLE
Add task transfer config support

### DIFF
--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/BpmTaskTransferConfigController.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/BpmTaskTransferConfigController.java
@@ -1,0 +1,71 @@
+package cn.iocoder.yudao.module.bpm.controller.admin.task;
+
+import cn.iocoder.yudao.framework.common.pojo.CommonResult;
+import cn.iocoder.yudao.framework.common.pojo.PageResult;
+import cn.iocoder.yudao.framework.common.util.object.BeanUtils;
+import cn.iocoder.yudao.module.bpm.controller.admin.task.vo.transfer.BpmTaskTransferConfigPageReqVO;
+import cn.iocoder.yudao.module.bpm.controller.admin.task.vo.transfer.BpmTaskTransferConfigRespVO;
+import cn.iocoder.yudao.module.bpm.controller.admin.task.vo.transfer.BpmTaskTransferConfigSaveReqVO;
+import cn.iocoder.yudao.module.bpm.dal.dataobject.task.BpmTaskTransferConfigDO;
+import cn.iocoder.yudao.module.bpm.service.task.BpmTaskTransferConfigService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Resource;
+import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import static cn.iocoder.yudao.framework.common.pojo.CommonResult.success;
+
+@Tag(name = "管理后台 - 任务转办配置")
+@RestController
+@RequestMapping("/bpm/task-transfer-config")
+@Validated
+public class BpmTaskTransferConfigController {
+
+    @Resource
+    private BpmTaskTransferConfigService transferConfigService;
+
+    @PostMapping("/create")
+    @Operation(summary = "创建转办配置")
+    @PreAuthorize("@ss.hasPermission('bpm:task-transfer-config:create')")
+    public CommonResult<Long> create(@Valid @RequestBody BpmTaskTransferConfigSaveReqVO createReqVO) {
+        return success(transferConfigService.createTaskTransferConfig(createReqVO));
+    }
+
+    @PutMapping("/update")
+    @Operation(summary = "更新转办配置")
+    @PreAuthorize("@ss.hasPermission('bpm:task-transfer-config:update')")
+    public CommonResult<Boolean> update(@Valid @RequestBody BpmTaskTransferConfigSaveReqVO updateReqVO) {
+        transferConfigService.updateTaskTransferConfig(updateReqVO);
+        return success(true);
+    }
+
+    @DeleteMapping("/delete")
+    @Operation(summary = "删除转办配置")
+    @Parameter(name = "id", description = "编号", required = true)
+    @PreAuthorize("@ss.hasPermission('bpm:task-transfer-config:delete')")
+    public CommonResult<Boolean> delete(@RequestParam("id") Long id) {
+        transferConfigService.deleteTaskTransferConfig(id);
+        return success(true);
+    }
+
+    @GetMapping("/get")
+    @Operation(summary = "获得转办配置")
+    @Parameter(name = "id", description = "编号", required = true)
+    @PreAuthorize("@ss.hasPermission('bpm:task-transfer-config:query')")
+    public CommonResult<BpmTaskTransferConfigRespVO> get(@RequestParam("id") Long id) {
+        BpmTaskTransferConfigDO config = transferConfigService.getTaskTransferConfig(id);
+        return success(BeanUtils.toBean(config, BpmTaskTransferConfigRespVO.class));
+    }
+
+    @GetMapping("/page")
+    @Operation(summary = "获得转办配置分页")
+    @PreAuthorize("@ss.hasPermission('bpm:task-transfer-config:query')")
+    public CommonResult<PageResult<BpmTaskTransferConfigRespVO>> page(@Valid BpmTaskTransferConfigPageReqVO pageVO) {
+        PageResult<BpmTaskTransferConfigDO> pageResult = transferConfigService.getTaskTransferConfigPage(pageVO);
+        return success(BeanUtils.toBean(pageResult, BpmTaskTransferConfigRespVO.class));
+    }
+}

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/vo/transfer/BpmTaskTransferConfigPageReqVO.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/vo/transfer/BpmTaskTransferConfigPageReqVO.java
@@ -1,0 +1,27 @@
+package cn.iocoder.yudao.module.bpm.controller.admin.task.vo.transfer;
+
+import cn.iocoder.yudao.framework.common.pojo.PageParam;
+import cn.iocoder.yudao.framework.common.util.date.DateUtils;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "管理后台 - 任务转办配置分页 Request VO")
+@Data
+public class BpmTaskTransferConfigPageReqVO extends PageParam {
+
+    @Schema(description = "原审批人用户编号", example = "1")
+    private Long fromUserId;
+
+    @Schema(description = "新审批人用户编号", example = "2")
+    private Long toUserId;
+
+    @Schema(description = "流程定义编号")
+    private String processDefinitionId;
+
+    @Schema(description = "创建时间")
+    @DateTimeFormat(pattern = DateUtils.FORMAT_YEAR_MONTH_DAY_HOUR_MINUTE_SECOND)
+    private LocalDateTime[] createTime;
+}

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/vo/transfer/BpmTaskTransferConfigRespVO.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/vo/transfer/BpmTaskTransferConfigRespVO.java
@@ -1,0 +1,35 @@
+package cn.iocoder.yudao.module.bpm.controller.admin.task.vo.transfer;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "管理后台 - 任务转办配置 Response VO")
+@Data
+public class BpmTaskTransferConfigRespVO {
+
+    @Schema(description = "编号", requiredMode = Schema.RequiredMode.REQUIRED, example = "1")
+    private Long id;
+
+    @Schema(description = "原审批人用户编号", requiredMode = Schema.RequiredMode.REQUIRED, example = "1")
+    private Long fromUserId;
+
+    @Schema(description = "新审批人用户编号", requiredMode = Schema.RequiredMode.REQUIRED, example = "2")
+    private Long toUserId;
+
+    @Schema(description = "流程定义编号")
+    private String processDefinitionId;
+
+    @Schema(description = "开始时间", requiredMode = Schema.RequiredMode.REQUIRED)
+    private LocalDateTime startTime;
+
+    @Schema(description = "结束时间", requiredMode = Schema.RequiredMode.REQUIRED)
+    private LocalDateTime endTime;
+
+    @Schema(description = "备注")
+    private String reason;
+
+    @Schema(description = "创建时间", requiredMode = Schema.RequiredMode.REQUIRED)
+    private LocalDateTime createTime;
+}

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/vo/transfer/BpmTaskTransferConfigSaveReqVO.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/vo/transfer/BpmTaskTransferConfigSaveReqVO.java
@@ -1,0 +1,40 @@
+package cn.iocoder.yudao.module.bpm.controller.admin.task.vo.transfer;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "管理后台 - 任务转办配置创建/修改 Request VO")
+@Data
+public class BpmTaskTransferConfigSaveReqVO {
+
+    @Schema(description = "编号", example = "1")
+    private Long id;
+
+    @Schema(description = "原审批人用户编号", requiredMode = Schema.RequiredMode.REQUIRED, example = "1")
+    @NotNull(message = "原审批人不能为空")
+    private Long fromUserId;
+
+    @Schema(description = "新审批人用户编号", requiredMode = Schema.RequiredMode.REQUIRED, example = "2")
+    @NotNull(message = "新审批人不能为空")
+    private Long toUserId;
+
+    @Schema(description = "流程定义编号")
+    private String processDefinitionId;
+
+    @Schema(description = "开始时间", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "开始时间不能为空")
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime startTime;
+
+    @Schema(description = "结束时间", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "结束时间不能为空")
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime endTime;
+
+    @Schema(description = "备注")
+    private String reason;
+}

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/dal/dataobject/task/BpmTaskTransferConfigDO.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/dal/dataobject/task/BpmTaskTransferConfigDO.java
@@ -1,0 +1,40 @@
+package cn.iocoder.yudao.module.bpm.dal.dataobject.task;
+
+import cn.iocoder.yudao.framework.mybatis.core.dataobject.BaseDO;
+import com.baomidou.mybatisplus.annotation.KeySequence;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 任务自动转办配置
+ */
+@TableName("bpm_task_transfer_config")
+@KeySequence("bpm_task_transfer_config_seq")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BpmTaskTransferConfigDO extends BaseDO {
+
+    /** 主键 */
+    @TableId
+    private Long id;
+    /** 原审批人 */
+    private Long fromUserId;
+    /** 新审批人 */
+    private Long toUserId;
+    /** 适用的流程定义编号，为空时表示全部流程 */
+    private String processDefinitionId;
+    /** 开始时间 */
+    private LocalDateTime startTime;
+    /** 结束时间 */
+    private LocalDateTime endTime;
+    /** 备注 */
+    private String reason;
+}

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/dal/mysql/task/BpmTaskTransferConfigMapper.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/dal/mysql/task/BpmTaskTransferConfigMapper.java
@@ -1,0 +1,21 @@
+package cn.iocoder.yudao.module.bpm.dal.mysql.task;
+
+import cn.iocoder.yudao.framework.common.pojo.PageResult;
+import cn.iocoder.yudao.framework.mybatis.core.mapper.BaseMapperX;
+import cn.iocoder.yudao.framework.mybatis.core.query.LambdaQueryWrapperX;
+import cn.iocoder.yudao.module.bpm.controller.admin.task.vo.transfer.BpmTaskTransferConfigPageReqVO;
+import cn.iocoder.yudao.module.bpm.dal.dataobject.task.BpmTaskTransferConfigDO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface BpmTaskTransferConfigMapper extends BaseMapperX<BpmTaskTransferConfigDO> {
+
+    default PageResult<BpmTaskTransferConfigDO> selectPage(BpmTaskTransferConfigPageReqVO reqVO) {
+        return selectPage(reqVO, new LambdaQueryWrapperX<BpmTaskTransferConfigDO>()
+                .eqIfPresent(BpmTaskTransferConfigDO::getFromUserId, reqVO.getFromUserId())
+                .eqIfPresent(BpmTaskTransferConfigDO::getToUserId, reqVO.getToUserId())
+                .eqIfPresent(BpmTaskTransferConfigDO::getProcessDefinitionId, reqVO.getProcessDefinitionId())
+                .betweenIfPresent(BpmTaskTransferConfigDO::getCreateTime, reqVO.getCreateTime())
+                .orderByDesc(BpmTaskTransferConfigDO::getId));
+    }
+}

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/BpmTaskTransferConfigService.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/BpmTaskTransferConfigService.java
@@ -1,0 +1,21 @@
+package cn.iocoder.yudao.module.bpm.service.task;
+
+import cn.iocoder.yudao.framework.common.pojo.PageResult;
+import cn.iocoder.yudao.module.bpm.controller.admin.task.vo.transfer.BpmTaskTransferConfigPageReqVO;
+import cn.iocoder.yudao.module.bpm.controller.admin.task.vo.transfer.BpmTaskTransferConfigSaveReqVO;
+import cn.iocoder.yudao.module.bpm.dal.dataobject.task.BpmTaskTransferConfigDO;
+
+import jakarta.validation.Valid;
+
+public interface BpmTaskTransferConfigService {
+
+    Long createTaskTransferConfig(@Valid BpmTaskTransferConfigSaveReqVO createReqVO);
+
+    void updateTaskTransferConfig(@Valid BpmTaskTransferConfigSaveReqVO updateReqVO);
+
+    void deleteTaskTransferConfig(Long id);
+
+    BpmTaskTransferConfigDO getTaskTransferConfig(Long id);
+
+    PageResult<BpmTaskTransferConfigDO> getTaskTransferConfigPage(BpmTaskTransferConfigPageReqVO pageReqVO);
+}

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/BpmTaskTransferConfigServiceImpl.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/BpmTaskTransferConfigServiceImpl.java
@@ -1,0 +1,58 @@
+package cn.iocoder.yudao.module.bpm.service.task;
+
+import cn.iocoder.yudao.framework.common.pojo.PageResult;
+import cn.iocoder.yudao.framework.common.util.object.BeanUtils;
+import cn.iocoder.yudao.module.bpm.controller.admin.task.vo.transfer.BpmTaskTransferConfigPageReqVO;
+import cn.iocoder.yudao.module.bpm.controller.admin.task.vo.transfer.BpmTaskTransferConfigSaveReqVO;
+import cn.iocoder.yudao.module.bpm.dal.dataobject.task.BpmTaskTransferConfigDO;
+import cn.iocoder.yudao.module.bpm.dal.mysql.task.BpmTaskTransferConfigMapper;
+import jakarta.annotation.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+@Service
+@Validated
+public class BpmTaskTransferConfigServiceImpl implements BpmTaskTransferConfigService {
+
+    @Resource
+    private BpmTaskTransferConfigMapper transferConfigMapper;
+
+    @Override
+    public Long createTaskTransferConfig(BpmTaskTransferConfigSaveReqVO createReqVO) {
+        BpmTaskTransferConfigDO config = BeanUtils.toBean(createReqVO, BpmTaskTransferConfigDO.class);
+        transferConfigMapper.insert(config);
+        return config.getId();
+    }
+
+    @Override
+    public void updateTaskTransferConfig(BpmTaskTransferConfigSaveReqVO updateReqVO) {
+        validateExists(updateReqVO.getId());
+        BpmTaskTransferConfigDO updateObj = BeanUtils.toBean(updateReqVO, BpmTaskTransferConfigDO.class);
+        transferConfigMapper.updateById(updateObj);
+    }
+
+    @Override
+    public void deleteTaskTransferConfig(Long id) {
+        validateExists(id);
+        transferConfigMapper.deleteById(id);
+    }
+
+    private void validateExists(Long id) {
+        if (id == null) {
+            return;
+        }
+        if (transferConfigMapper.selectById(id) == null) {
+            throw new IllegalArgumentException("task transfer config not found");
+        }
+    }
+
+    @Override
+    public BpmTaskTransferConfigDO getTaskTransferConfig(Long id) {
+        return transferConfigMapper.selectById(id);
+    }
+
+    @Override
+    public PageResult<BpmTaskTransferConfigDO> getTaskTransferConfigPage(BpmTaskTransferConfigPageReqVO pageReqVO) {
+        return transferConfigMapper.selectPage(pageReqVO);
+    }
+}


### PR DESCRIPTION
## Summary
- add `BpmTaskTransferConfigDO` and mapper
- add service to manage transfer configs
- expose admin controller for CRUD
- add related request/response VOs

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684679f7b1c88320ae3ba14a6d69aea5