### PR TITLE
Add cancel task API

### DIFF
--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/BpmTaskController.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/BpmTaskController.java
@@ -405,6 +405,14 @@ public class BpmTaskController {
         return success(true);
     }
 
+    @DeleteMapping("/cancel")
+    @Operation(summary = "取消任务")
+    @PreAuthorize("@ss.hasPermission('bpm:task:update')")
+    public CommonResult<Boolean> cancelTask(@Valid @RequestBody BpmTaskCancelReqVO reqVO) {
+        bpmTaskService.cancelTask(getLoginUserId(), reqVO);
+        return success(true);
+    }
+
     @PutMapping("/copy")
     @Operation(summary = "抄送任务")
     @PreAuthorize("@ss.hasPermission('bpm:task:update')")

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/vo/task/BpmTaskCancelReqVO.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/vo/task/BpmTaskCancelReqVO.java
@@ -1,0 +1,21 @@
+package cn.iocoder.yudao.module.bpm.controller.admin.task.vo.task;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+@Schema(description = "管理后台 - 取消流程任务的 Request VO")
+@Data
+public class BpmTaskCancelReqVO {
+
+    @Schema(description = "任务编号", requiredMode = Schema.RequiredMode.REQUIRED, example = "1024")
+    @NotEmpty(message = "任务编号不能为空")
+    private String id;
+
+    @Schema(description = "取消原因", requiredMode = Schema.RequiredMode.REQUIRED, example = "无需处理")
+    @NotEmpty(message = "取消原因不能为空")
+    private String reason;
+
+    @Schema(description = "是否是管理员", requiredMode = Schema.RequiredMode.REQUIRED, example = "false")
+    private Boolean managerial = false;
+}

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/BpmTaskService.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/BpmTaskService.java
@@ -239,6 +239,14 @@ public interface BpmTaskService {
     void deleteSignTask(Long userId, BpmTaskSignDeleteReqVO reqVO);
 
     /**
+     * 取消任务
+     *
+     * @param userId 用户编号
+     * @param reqVO  取消任务的请求
+     */
+    void cancelTask(Long userId, BpmTaskCancelReqVO reqVO);
+
+    /**
      * 抄送任务
      *
      * @param userId 用户编号


### PR DESCRIPTION
## Summary
- add BpmTaskCancelReqVO
- add cancelTask method to service and implementation
- expose `/bpm/task/cancel` endpoint

## Testing
- `mvn -q -am -pl yudao-module-bpm -DskipTests compile` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ba50983f08320b82a1b7c991799a1