### PR TITLE
Add form search in done tasks and expose model form versions

### DIFF
--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/BpmModelController.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/BpmModelController.java
@@ -201,6 +201,12 @@ public class BpmModelController {
         return success(modelService.getModelVersionList());
     }
 
+    @GetMapping("/version-form-list")
+    @Operation(summary = "获得流程模型版本表单项列表")
+    public CommonResult<List<BpmModelVersionFormRespVO>> getModelVersionFormList() {
+        return success(modelService.getModelVersionFormList());
+    }
+
     @Deprecated
     @PostMapping("/simple/update")
     @Operation(summary = "保存仿钉钉流程设计模型")

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/vo/model/BpmModelVersionFormRespVO.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/vo/model/BpmModelVersionFormRespVO.java
@@ -1,0 +1,31 @@
+package cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 管理后台 - 流程模型版本及表单项 Response VO
+ */
+@Data
+public class BpmModelVersionFormRespVO {
+
+    @Schema(description = "流程模型编号", example = "a2c5eee0")
+    private String id;
+
+    @Schema(description = "流程模型名称", example = "请假流程")
+    private String name;
+
+    @Schema(description = "流程版本及表单项列表")
+    private List<VersionInfo> versions;
+
+    @Data
+    public static class VersionInfo {
+        @Schema(description = "流程版本号", example = "1")
+        private Integer version;
+
+        @Schema(description = "表单项数组")
+        private List<String> formFields;
+    }
+}

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/vo/task/BpmTaskPageReqVO.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/task/vo/task/BpmTaskPageReqVO.java
@@ -21,5 +21,8 @@ public class BpmTaskPageReqVO extends PageParam {
     //流程实例名称
     private String processInstanceName;
 
+    @Schema(description = "动态表单字段查询 JSON Str", example = "{}")
+    private String formFieldsParams; // 以 JSON 字符串的形式传递表单字段查询参数
+
 
 }

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmModelService.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmModelService.java
@@ -4,6 +4,7 @@ import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.BpmModel
 import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.simple.BpmSimpleModelNodeVO;
 import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.simple.BpmSimpleModelUpdateReqVO;
 import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.BpmModelVersionRespVO;
+import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.BpmModelVersionFormRespVO;
 import jakarta.validation.Valid;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.engine.repository.Model;
@@ -147,5 +148,12 @@ public interface BpmModelService {
      * @return 模型版本信息列表
      */
     List<BpmModelVersionRespVO> getModelVersionList();
+
+    /**
+     * 获取所有流程模型及其版本对应的表单项列表
+     *
+     * @return 模型版本及表单项信息列表
+     */
+    List<BpmModelVersionFormRespVO> getModelVersionFormList();
 
 }

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/BpmTaskServiceImpl.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/BpmTaskServiceImpl.java
@@ -10,6 +10,7 @@ import cn.iocoder.yudao.framework.common.util.date.LocalDateTimeUtils;
 import cn.iocoder.yudao.framework.common.util.number.NumberUtils;
 import cn.iocoder.yudao.framework.common.util.object.ObjectUtils;
 import cn.iocoder.yudao.framework.common.util.object.PageUtils;
+import cn.iocoder.yudao.framework.common.util.json.JsonUtils;
 import cn.iocoder.yudao.framework.web.core.util.WebFrameworkUtils;
 import cn.iocoder.yudao.module.bpm.controller.admin.task.vo.task.*;
 import cn.iocoder.yudao.module.bpm.convert.task.BpmTaskConvert;
@@ -281,6 +282,16 @@ public class BpmTaskServiceImpl implements BpmTaskService {
             LocalDateTime endTime = LocalDateTimeUtils.parse(pageVO.getCreateTime()[1]);
             query.taskCreatedAfter(DateUtils.of(startTime));
             query.taskCreatedBefore(DateUtils.of(endTime));
+        }
+        // 表单字段模糊查询
+        Map<String, Object> formFieldsParams = JsonUtils.parseObject(pageVO.getFormFieldsParams(), Map.class);
+        if (CollUtil.isNotEmpty(formFieldsParams)) {
+            formFieldsParams.forEach((key, value) -> {
+                if (StrUtil.isEmpty(String.valueOf(value))) {
+                    return;
+                }
+                query.processVariableValueLikeIgnoreCase(key, "%" + value + "%");
+            });
         }
         return query;
     }


### PR DESCRIPTION
## Summary
- support searching done tasks by form contents
- return process model versions with form fields via new endpoint

## Testing
- `mvn` command was not found so tests could not be run

------
https://chatgpt.com/codex/tasks/task_b_684bc9cdc4a483209e88352becedd2b5