### PR TITLE
Add ability to edit historic BPM models

### DIFF
--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/BpmModelController.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/BpmModelController.java
@@ -98,15 +98,18 @@ public class BpmModelController {
 
     @GetMapping("/get")
     @Operation(summary = "获得模型")
-    @Parameter(name = "id", description = "编号", required = true, example = "1024")
+    @Parameter(name = "id", description = "编号", example = "1024")
+    @Parameter(name = "processDefinitionId", description = "流程定义编号", example = "a2c5eee0")
     @PreAuthorize("@ss.hasPermission('bpm:model:query')")
-    public CommonResult<BpmModelRespVO> getModel(@RequestParam("id") String id) {
-        Model model = modelService.getModel(id);
+    public CommonResult<BpmModelRespVO> getModel(@RequestParam(value = "id", required = false) String id,
+                                                 @RequestParam(value = "processDefinitionId", required = false) String processDefinitionId) {
+        Model model = modelService.getModel(id, processDefinitionId);
         if (model == null) {
             return null;
         }
-        byte[] bpmnBytes = modelService.getModelBpmnXML(id);
-        BpmSimpleModelNodeVO simpleModel = modelService.getSimpleModel(id);
+        String realId = model.getId();
+        byte[] bpmnBytes = modelService.getModelBpmnXML(realId);
+        BpmSimpleModelNodeVO simpleModel = modelService.getSimpleModel(realId);
         return success(BpmModelConvert.INSTANCE.buildModel(model, bpmnBytes, simpleModel));
     }
 
@@ -127,9 +130,11 @@ public class BpmModelController {
 
     @PutMapping("/update")
     @Operation(summary = "修改模型")
+    @Parameter(name = "processDefinitionId", description = "流程定义编号", example = "a2c5eee0")
     @PreAuthorize("@ss.hasPermission('bpm:model:update')")
-    public CommonResult<Boolean> updateModel(@Valid @RequestBody BpmModelSaveReqVO modelVO) {
-        modelService.updateModel(getLoginUserId(), modelVO);
+    public CommonResult<Boolean> updateModel(@Valid @RequestBody BpmModelSaveReqVO modelVO,
+                                             @RequestParam(value = "processDefinitionId", required = false) String processDefinitionId) {
+        modelService.updateModel(getLoginUserId(), modelVO, processDefinitionId);
         return success(true);
     }
 

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmModelService.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmModelService.java
@@ -41,6 +41,15 @@ public interface BpmModelService {
     Model getModel(String id);
 
     /**
+     * 获得流程模块
+     *
+     * @param id 编号
+     * @param processDefinitionId 历史流程定义编号
+     * @return 流程模型
+     */
+    Model getModel(String id, String processDefinitionId);
+
+    /**
      * 获得流程模型的 BPMN XML
      *
      * @param id 编号
@@ -63,6 +72,15 @@ public interface BpmModelService {
      * @param updateReqVO 更新信息
      */
     void updateModel(Long userId, @Valid BpmModelSaveReqVO updateReqVO);
+
+    /**
+     * 修改流程模型
+     *
+     * @param userId 用户编号
+     * @param updateReqVO 更新信息
+     * @param processDefinitionId 历史流程定义编号
+     */
+    void updateModel(Long userId, @Valid BpmModelSaveReqVO updateReqVO, String processDefinitionId);
 
     /**
      * 批量更新模型排序

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmModelServiceImpl.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmModelServiceImpl.java
@@ -127,6 +127,18 @@ public class BpmModelServiceImpl implements BpmModelService {
         saveModel(model, updateReqVO);
     }
 
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void updateModel(Long userId, BpmModelSaveReqVO updateReqVO, String processDefinitionId) {
+        if (StrUtil.isNotEmpty(processDefinitionId)) {
+            BpmProcessDefinitionInfoDO info = processDefinitionService.getProcessDefinitionInfo(processDefinitionId);
+            if (info != null) {
+                updateReqVO.setId(info.getModelId());
+            }
+        }
+        updateModel(userId, updateReqVO);
+    }
+
     /**
      * 保存模型的基本信息、流程图
      *
@@ -415,6 +427,21 @@ public class BpmModelServiceImpl implements BpmModelService {
 
     @Override
     public Model getModel(String id) {
+        return repositoryService.getModel(id);
+    }
+
+    @Override
+    public Model getModel(String id, String processDefinitionId) {
+        if (StrUtil.isNotEmpty(processDefinitionId)) {
+            BpmProcessDefinitionInfoDO info = processDefinitionService.getProcessDefinitionInfo(processDefinitionId);
+            if (info == null) {
+                return null;
+            }
+            id = info.getModelId();
+        }
+        if (StrUtil.isEmpty(id)) {
+            return null;
+        }
         return repositoryService.getModel(id);
     }
 

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmModelServiceImpl.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmModelServiceImpl.java
@@ -134,6 +134,7 @@ public class BpmModelServiceImpl implements BpmModelService {
             BpmProcessDefinitionInfoDO info = processDefinitionService.getProcessDefinitionInfo(processDefinitionId);
             if (info != null) {
                 updateReqVO.setId(info.getModelId());
+                processDefinitionService.updateProcessDefinitionInfo(processDefinitionId, updateReqVO);
             }
         }
         updateModel(userId, updateReqVO);

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmProcessDefinitionService.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmProcessDefinitionService.java
@@ -178,4 +178,12 @@ public interface BpmProcessDefinitionService {
      */
     Deployment getDeployment(String id);
 
+    /**
+     * 更新流程定义的扩展信息
+     *
+     * @param processDefinitionId 流程定义编号
+     * @param updateReqVO 流程模型信息
+     */
+    void updateProcessDefinitionInfo(String processDefinitionId, BpmModelSaveReqVO updateReqVO);
+
 }


### PR DESCRIPTION
## Summary
- support getting model by processDefinitionId
- support updating model by processDefinitionId

## Testing
- `mvn -q -DskipTests -pl yudao-module-bpm -am package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68513501ec648320bf800411d89a3e84