### PR TITLE
Add history model editing

### DIFF
--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/BpmModelController.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/BpmModelController.java
@@ -14,6 +14,7 @@ import cn.iocoder.yudao.module.bpm.service.definition.BpmModelService;
 import cn.iocoder.yudao.module.bpm.service.definition.BpmProcessDefinitionService;
 import cn.iocoder.yudao.module.system.api.user.AdminUserApi;
 import cn.iocoder.yudao.module.system.api.user.dto.AdminUserRespDTO;
+import cn.hutool.core.util.StrUtil;
 import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.BpmModelVersionRespVO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -99,9 +100,14 @@ public class BpmModelController {
 
     @GetMapping("/get")
     @Operation(summary = "获得模型")
-    @Parameter(name = "id", description = "编号", required = true, example = "1024")
+    @Parameter(name = "id", description = "编号", example = "1024")
+    @Parameter(name = "processDefinitionId", description = "流程定义编号")
     @PreAuthorize("@ss.hasPermission('bpm:model:query')")
-    public CommonResult<BpmModelRespVO> getModel(@RequestParam("id") String id) {
+    public CommonResult<BpmModelRespVO> getModel(@RequestParam(value = "id", required = false) String id,
+                                                 @RequestParam(value = "processDefinitionId", required = false) String processDefinitionId) {
+        if (StrUtil.isNotEmpty(processDefinitionId)) {
+            return success(modelService.getHistoryModel(processDefinitionId));
+        }
         Model model = modelService.getModel(id);
         if (model == null) {
             return null;

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/vo/model/BpmModelSaveReqVO.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/vo/model/BpmModelSaveReqVO.java
@@ -31,4 +31,7 @@ public class BpmModelSaveReqVO extends BpmModelMetaInfoVO {
     @Valid
     private BpmSimpleModelNodeVO simpleModel;
 
+    @Schema(description = "历史流程定义编号", example = "a2c5eee0-1")
+    private String processDefinitionId;
+
 }

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmModelService.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmModelService.java
@@ -4,6 +4,7 @@ import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.BpmModel
 import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.simple.BpmSimpleModelNodeVO;
 import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.simple.BpmSimpleModelUpdateReqVO;
 import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.BpmModelVersionRespVO;
+import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.BpmModelRespVO;
 import jakarta.validation.Valid;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.engine.repository.Model;
@@ -147,5 +148,22 @@ public interface BpmModelService {
      * @return 模型版本信息列表
      */
     List<BpmModelVersionRespVO> getModelVersionList();
+
+    /**
+     * 获取历史流程模型
+     *
+     * @param processDefinitionId 流程定义编号
+     * @return 流程模型
+     */
+    BpmModelRespVO getHistoryModel(String processDefinitionId);
+
+    /**
+     * 更新历史流程模型
+     *
+     * @param userId 用户编号
+     * @param processDefinitionId 流程定义编号
+     * @param reqVO 更新信息
+     */
+    void updateHistoryModel(Long userId, String processDefinitionId, @Valid BpmModelSaveReqVO reqVO);
 
 }

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmModelServiceImpl.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmModelServiceImpl.java
@@ -5,6 +5,7 @@ import cn.hutool.core.util.ArrayUtil;
 import cn.hutool.core.util.ObjUtil;
 import cn.hutool.core.util.StrUtil;
 import cn.iocoder.yudao.framework.common.util.json.JsonUtils;
+import cn.iocoder.yudao.framework.common.util.object.BeanUtils;
 import cn.iocoder.yudao.framework.common.util.validation.ValidationUtils;
 import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.BpmModelMetaInfoVO;
 import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.BpmModelSaveReqVO;
@@ -120,6 +121,11 @@ public class BpmModelServiceImpl implements BpmModelService {
     @Override
     @Transactional(rollbackFor = Exception.class) // 因为进行多个操作，所以开启事务
     public void updateModel(Long userId, BpmModelSaveReqVO updateReqVO) {
+        if (StrUtil.isNotEmpty(updateReqVO.getProcessDefinitionId())) {
+            updateHistoryModel(userId, updateReqVO.getProcessDefinitionId(), updateReqVO);
+            return;
+        }
+
         // 1. 校验流程模型存在
         Model model = validateModelManager(updateReqVO.getId(), userId);
 
@@ -526,6 +532,43 @@ public class BpmModelServiceImpl implements BpmModelService {
             result.add(vo);
         }
         return result;
+    }
+
+    @Override
+    public BpmModelRespVO getHistoryModel(String processDefinitionId) {
+        BpmProcessDefinitionInfoDO info = processDefinitionService.getProcessDefinitionInfo(processDefinitionId);
+        if (info == null) {
+            return null;
+        }
+        Model model = getModel(info.getModelId());
+        if (model == null) {
+            return null;
+        }
+        String oldMeta = model.getMetaInfo();
+        model.setMetaInfo(JsonUtils.toJsonString(BeanUtils.toBean(info, BpmModelMetaInfoVO.class)));
+        BpmnModel bpmnModel = processDefinitionService.getProcessDefinitionBpmnModel(processDefinitionId);
+        byte[] bpmnBytes = bpmnModel != null ? cn.hutool.core.util.StrUtil.utf8Bytes(BpmnModelUtils.getBpmnXml(bpmnModel)) : null;
+        BpmSimpleModelNodeVO simpleModel = JsonUtils.parseObject(info.getSimpleModel(), BpmSimpleModelNodeVO.class);
+        BpmModelRespVO respVO = BpmModelConvert.INSTANCE.buildModel(model, bpmnBytes, simpleModel);
+        model.setMetaInfo(oldMeta);
+        return respVO;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void updateHistoryModel(Long userId, String processDefinitionId, @Valid BpmModelSaveReqVO reqVO) {
+        BpmProcessDefinitionInfoDO info = processDefinitionService.getProcessDefinitionInfo(processDefinitionId);
+        if (info == null) {
+            throw exception(PROCESS_DEFINITION_NOT_EXISTS);
+        }
+        validateModelManager(info.getModelId(), userId);
+
+        BpmProcessDefinitionInfoDO updateObj = BeanUtils.toBean(reqVO, BpmProcessDefinitionInfoDO.class);
+        updateObj.setId(info.getId());
+        if (reqVO.getSimpleModel() != null) {
+            updateObj.setSimpleModel(JsonUtils.toJsonString(reqVO.getSimpleModel()));
+        }
+        processDefinitionInfoMapper.updateById(updateObj);
     }
 
 }


### PR DESCRIPTION
## Summary
- allow specifying historic process definitions when fetching models
- support updating meta info on historic model versions

## Testing
- `mvn -q -pl yudao-module-bpm -am test -DskipTests` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685138b307e48320b55439e3cccda68a