### PR TITLE
Handle missing condition variables

### DIFF
--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/framework/flowable/core/el/EqualsExpressionFunction.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/framework/flowable/core/el/EqualsExpressionFunction.java
@@ -1,0 +1,36 @@
+package cn.iocoder.yudao.module.bpm.framework.flowable.core.el;
+
+import org.flowable.common.engine.api.variable.VariableContainer;
+import org.flowable.common.engine.impl.el.function.AbstractFlowableVariableExpressionFunction;
+import org.springframework.stereotype.Component;
+import cn.iocoder.yudao.module.bpm.framework.flowable.core.util.VariableTypeUtils;
+
+import java.util.Objects;
+
+/**
+ * 自定义 equals 表达式函数，避免变量不存在时抛出异常
+ */
+@Component
+public class EqualsExpressionFunction extends AbstractFlowableVariableExpressionFunction {
+
+    public EqualsExpressionFunction() {
+        super("equals");
+    }
+
+    /**
+     * 判断变量与参数是否相等，变量不存在时返回 false
+     *
+     * @param variableContainer 变量容器
+     * @param variableName      变量名
+     * @param paramValue        参数值
+     * @return 是否相等
+     */
+    public static boolean equals(VariableContainer variableContainer, String variableName, Object paramValue) {
+        Object variable = variableContainer.getVariable(variableName);
+        if (variable == null) {
+            return false;
+        }
+        Object converted = VariableTypeUtils.convertByType(variable, paramValue);
+        return Objects.equals(variable, converted);
+    }
+}

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/framework/flowable/core/util/SimpleModelUtils.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/framework/flowable/core/util/SimpleModelUtils.java
@@ -732,13 +732,21 @@ public class SimpleModelUtils {
                     }
                     // 处理 contains 和 notContains 操作符
                     if ("contains".equals(rule.getOpCode())) {
-                        return String.format("var:contains(%s, %s)", rule.getLeftSide(), rightSide);
+                        // 传入变量名，变量不存在时返回 false
+                        return String.format("var:contains(\"%s\", %s)", rule.getLeftSide(), rightSide);
                     } else if ("notContains".equals(rule.getOpCode())) {
-                        return String.format("!var:contains(%s, %s)", rule.getLeftSide(), rightSide);
+                        // 传入变量名，变量不存在时返回 false
+                        return String.format("!var:contains(\"%s\", %s)", rule.getLeftSide(), rightSide);
+                    } else if ("==".equals(rule.getOpCode())) {
+                        // 使用自定义 equals 函数，变量不存在时返回 false
+                        return String.format("var:equals(\"%s\", %s)", rule.getLeftSide(), rightSide);
+                    } else if ("!=".equals(rule.getOpCode())) {
+                        // 不等于时取反即可
+                        return String.format("!var:equals(\"%s\", %s)", rule.getLeftSide(), rightSide);
                     } else {
                         // 其他操作符使用原有转换逻辑
                         // 优化：将 rightSide 直接传递给 convertByType
-                        return String.format("%s %s var:convertByType(%s, %s)",
+                        return String.format("%s %s var:convertByType(\"%s\", %s)",
                                 rule.getLeftSide(), rule.getOpCode(), rule.getLeftSide(), rightSide);
                     }
                 });


### PR DESCRIPTION
## Summary
- add `EqualsExpressionFunction` to safely compare values
- build expressions using variable names to prevent missing-variable errors

## Testing
- `mvn -q -pl yudao-module-bpm -am -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685291b4fbb4832093691519bfca0677